### PR TITLE
Add MiniMessage support for scoreboards

### DIFF
--- a/src/main/java/com/luacraft/ScriptLoader.java
+++ b/src/main/java/com/luacraft/ScriptLoader.java
@@ -17,6 +17,7 @@ import org.luaj.vm2.lib.jse.JsePlatform;
 import com.luacraft.sandbox.chat.ChatLib;
 import com.luacraft.sandbox.command.CommandLib;
 import com.luacraft.sandbox.component.ComponentFactory;
+import com.luacraft.sandbox.component.MiniMessageFactory;
 import com.luacraft.sandbox.database.SQLiteLuaLib;
 import com.luacraft.sandbox.events.EventTable;
 import com.luacraft.sandbox.inventory.InventoryFactory;
@@ -64,6 +65,7 @@ public class ScriptLoader {
         globals.set("Itemstack", new ItemStackFactory());
         globals.set("Location", new LocationFactory());
         globals.set("Component", new ComponentFactory());
+        globals.set("MiniMessage", new MiniMessageFactory());
         globals.set("Inventory", new InventoryFactory());
         globals.set("Wait", WaitUtil.Wait(mainPlugin));
         globals.set("PlayerUtil", new PlayerUtil());

--- a/src/main/java/com/luacraft/sandbox/component/MiniMessageFactory.java
+++ b/src/main/java/com/luacraft/sandbox/component/MiniMessageFactory.java
@@ -1,0 +1,18 @@
+package com.luacraft.sandbox.component;
+
+import org.luaj.vm2.LuaValue;
+import org.luaj.vm2.lib.OneArgFunction;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+
+public class MiniMessageFactory extends OneArgFunction {
+    private static final MiniMessage MINI_MESSAGE = MiniMessage.miniMessage();
+
+    @Override
+    public LuaValue call(LuaValue arg) {
+        String input = arg.checkjstring();
+        Component parsed = MINI_MESSAGE.deserialize(input);
+        return new ComponentLib(parsed);
+    }
+}

--- a/src/main/java/com/luacraft/sandbox/scoreboard/ScoreLib.java
+++ b/src/main/java/com/luacraft/sandbox/scoreboard/ScoreLib.java
@@ -27,6 +27,17 @@ public class ScoreLib extends LuaTable {
             }
         });
 
+        rawset(LuaValue.valueOf("SetCustomName"), new OneArgFunction() {
+            @Override
+            public LuaValue call(LuaValue displayName) {
+                Component customName = ComponentUtils.luaValueToComponent(displayName);
+
+                score.customName(customName);
+
+                return LuaValue.NIL;
+            }
+        });
+
         rawset(LuaValue.valueOf("SetNumberFormat"), new TwoArgFunction() {
             @Override
             public LuaValue call(LuaValue type, LuaValue component) {


### PR DESCRIPTION
> [!NOTE]
> This PR was AI-generated and is just a test.

Adds MiniMessage parsing to the Lua API so scripts can use MiniMessage format strings for scoreboard styling (gradients, hex colors, click events, etc).

### Changes
- New `MiniMessage()` global — parses a MiniMessage string into an Adventure Component, works anywhere a Component is accepted
- New `SetCustomName` on `ScoreLib` — allows setting styled display names on individual score entries
- Registered `MiniMessage` in `ScriptLoader.setupGlobals()`

### Example usage
```lua
local scoreboard = Scoreboard()
local objective = scoreboard.NewObjective("demo", MiniMessage("<gradient:gold:yellow>My Server</gradient>"))
objective.SetDisplaySlot("SIDEBAR")
objective.SetNumberFormat("blank")

local score = objective.GetScore("line1")
score.SetScore(1)
score.SetCustomName(MiniMessage("<rainbow>Hello World</rainbow>"))
```